### PR TITLE
Update build.cmd

### DIFF
--- a/local/build.cmd
+++ b/local/build.cmd
@@ -12,7 +12,7 @@ rem --------------------------------------------------------------------
 
 cd ..
 SET ZLib_repo="https://github.com/madler/zlib"
-SET ZLib_version="v1.2.11"
+SET ZLib_version="v1.3"
 IF NOT EXIST zlib (git clone -q --branch=%ZLib_version% %ZLib_repo% zlib)
 powershell -ExecutionPolicy Bypass .\build-zlib.ps1 %1 %2 -configure
 cd %~dp0


### PR DESCRIPTION
Use zLib version 1.3.
Version 1.2.11 contains a **critical scored vulnerability** as described here: https://nvd.nist.gov/vuln/detail/CVE-2022-37434